### PR TITLE
Event title moved above image

### DIFF
--- a/Countdown-Widget/DetailedView.storyboard
+++ b/Countdown-Widget/DetailedView.storyboard
@@ -17,12 +17,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Event Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s0c-di-Frp">
-                                <rect key="frame" x="10" y="339" width="373" height="40.666666666666686"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cKn-cV-BZC">
                                 <rect key="frame" x="10" y="738" width="373" height="35"/>
                                 <state key="normal" title="Button"/>
@@ -42,16 +36,16 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2kf-r2-2Km">
-                                <rect key="frame" x="0.0" y="379.66666666666674" width="393" height="358.33333333333326"/>
+                                <rect key="frame" x="0.0" y="359" width="393" height="379"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="23" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wJj-Oy-weu">
-                                        <rect key="frame" x="138.66666666666666" y="99.333333333333314" width="116" height="120"/>
+                                        <rect key="frame" x="138.66666666666666" y="109.66666666666669" width="116" height="120"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="100"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Days Left" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iiM-2U-vDt">
-                                        <rect key="frame" x="155" y="229.33333333333331" width="83" height="24"/>
+                                        <rect key="frame" x="155" y="239.66666666666663" width="83" height="24"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -66,7 +60,7 @@
                                 </constraints>
                             </view>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="RhX-yV-z6m">
-                                <rect key="frame" x="0.0" y="9" width="393" height="300"/>
+                                <rect key="frame" x="0.0" y="59" width="393" height="300"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="300" id="hHl-BI-vaA"/>
                                 </constraints>
@@ -76,21 +70,18 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="2kf-r2-2Km" secondAttribute="trailing" id="0Of-kW-KQX"/>
-                            <constraint firstItem="RhX-yV-z6m" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="-50" id="Cmp-yp-bTm"/>
+                            <constraint firstItem="RhX-yV-z6m" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="Cmp-yp-bTm"/>
                             <constraint firstItem="RhX-yV-z6m" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="FRF-Ih-As7"/>
                             <constraint firstItem="B4p-S4-qps" firstAttribute="top" secondItem="cKn-cV-BZC" secondAttribute="bottom" constant="10" id="HEZ-YG-IWl"/>
                             <constraint firstItem="cKn-cV-BZC" firstAttribute="top" secondItem="2kf-r2-2Km" secondAttribute="bottom" id="I5v-jg-Qlg"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="RhX-yV-z6m" secondAttribute="trailing" id="MHN-QC-Qzh"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="s0c-di-Frp" secondAttribute="trailing" constant="10" id="Rm2-76-YbY"/>
                             <constraint firstItem="cKn-cV-BZC" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="10" id="TsL-T0-vVn"/>
+                            <constraint firstItem="2kf-r2-2Km" firstAttribute="top" secondItem="RhX-yV-z6m" secondAttribute="bottom" id="U6g-tY-duo"/>
                             <constraint firstItem="B4p-S4-qps" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="10" id="Uo9-o6-V6D"/>
                             <constraint firstItem="B4p-S4-qps" firstAttribute="bottom" secondItem="vDu-zF-Fre" secondAttribute="bottom" id="XYp-v6-jPP"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="cKn-cV-BZC" secondAttribute="trailing" constant="10" id="ar6-zO-L4i"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="B4p-S4-qps" secondAttribute="trailing" constant="10" id="eZ9-tx-S5k"/>
-                            <constraint firstItem="s0c-di-Frp" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="10" id="gFT-DL-bO6"/>
                             <constraint firstItem="2kf-r2-2Km" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="jVv-nT-X3i"/>
-                            <constraint firstItem="s0c-di-Frp" firstAttribute="top" secondItem="RhX-yV-z6m" secondAttribute="bottom" constant="30" id="qEO-41-GBJ"/>
-                            <constraint firstItem="2kf-r2-2Km" firstAttribute="top" secondItem="s0c-di-Frp" secondAttribute="bottom" id="qHJ-CK-HHM"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="pkI-gY-xhb"/>
@@ -100,7 +91,6 @@
                         <outlet property="detailedImageView" destination="RhX-yV-z6m" id="kqo-Y3-Iih"/>
                         <outlet property="detailedRemoveEventButton" destination="B4p-S4-qps" id="Ati-Sr-GtS"/>
                         <outlet property="detailedTimeLeftLabel" destination="wJj-Oy-weu" id="Rsv-ej-RLe"/>
-                        <outlet property="detailedTitleLabel" destination="s0c-di-Frp" id="rAQ-L6-16P"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/Countdown-Widget/DetailedViewController.swift
+++ b/Countdown-Widget/DetailedViewController.swift
@@ -10,7 +10,6 @@ import CoreData
 
 class DetailedViewController: UIViewController {
 
-    @IBOutlet weak var detailedTitleLabel: UILabel!
     @IBOutlet weak var detailedTimeLeftLabel: UILabel!
     @IBOutlet weak var detailedDaysLeftLabel: UILabel!
     @IBOutlet weak var detailedEditEventButton: UIButton!
@@ -30,7 +29,7 @@ class DetailedViewController: UIViewController {
     
     override func viewDidLoad() {
         if titleText != nil {
-            detailedTitleLabel.text = titleText
+            self.title = titleText
         }
 
         if image != nil {
@@ -61,7 +60,7 @@ class DetailedViewController: UIViewController {
 
     // Update all elements in the UI after editing an event
     func updateDetailedUI() {
-        detailedTitleLabel.text = self.UserEventsList![self.eventIndex!].title
+        self.title = self.UserEventsList![self.eventIndex!].title
         detailedImageView.image =  UIImage(data: self.UserEventsList![self.eventIndex!].image!)
         detailedTimeLeftLabel.text = String(daysLeft(date: self.UserEventsList![self.eventIndex!].date!))
     }
@@ -103,7 +102,7 @@ class DetailedViewController: UIViewController {
             viewController.isEditingEvent = true
 
             viewController.editingImage = detailedImageView.image
-            viewController.editingTitle = detailedTitleLabel.text
+            viewController.editingTitle = self.title
 
             if eventDate != nil {
                 viewController.editingDate = eventDate


### PR DESCRIPTION
The problem was that the view title, although being empty, was still there. Moving the title above the image, that is, removing the custom one and using the view title, fixes this and removes the need to use a negative constraint for the image.