### PR TITLE
Fix need of long press in date picker

### DIFF
--- a/Countdown-Widget/AddItemView.swift
+++ b/Countdown-Widget/AddItemView.swift
@@ -67,6 +67,9 @@ struct AddItemView: View {
                         displayedComponents: [.date]
                     )
                     .datePickerStyle(.graphical)
+                    .onTapGesture(count: 99, perform: {
+                        // Override iOS bug
+                    })
 
 
             }


### PR DESCRIPTION
The issue was a bug in an update of iOS 17.1. Updating the `onTapGesture` property fixes it.

Source: https://stackoverflow.com/questions/77373659/swiftui-datepicker-issue-ios-17-1

Closes #51.